### PR TITLE
Switch to mason since nvim-lsp-installer is now deprecated.

### DIFF
--- a/lua/defaults.d/lsp-conf.lua
+++ b/lua/defaults.d/lsp-conf.lua
@@ -1,17 +1,14 @@
--- LSP {{{
-
 local lspconfig = require('lspconfig')
 
 vim.diagnostic.config({
     virtual_text = true,
 })
 
--- Formatting{{{
+-- Formatting
 -- Map :Format to vim.lsp.buf.formatting()
 vim.cmd [[command! Format execute 'lua vim.lsp.buf.format { async = true }']]
---}}}
 
--- Aesthetics{{{
+-- Aesthetics
 local signs = { Error = " ", Warning = " ", Hint = " ", Information = " " }
 
 for type, icon in pairs(signs) do
@@ -19,14 +16,9 @@ for type, icon in pairs(signs) do
 
     vim.fn.sign_define(hl, { text = icon, texthl = hl, numhl = "" })
 end
---}}}
 
--- lsp-installer{{{
-local lsp_installer = require("nvim-lsp-installer")
-
--- Provide settings first!
-lsp_installer.settings {
-    automatic_installation = true,
+-- lsp-installer
+require("mason").setup({
     ui = {
         icons = {
             server_installed = "✓",
@@ -34,53 +26,38 @@ lsp_installer.settings {
             server_uninstalled = "✗"
         }
     }
-}
+})
 
--- lsp_installer.on_server_ready(
---     function(server)
---         server:setup {}
---     end
--- )
---}}}
+require("mason-lspconfig").setup({
+    ensure_installed = { "bashls", "clang", "gopls", "sumneko_lua" },
+    automatic_installation = true,
+})
 
--- Extra server config{{{
---
--- Typescript{{{
--- I have no idea if this works
-lspconfig.tsserver.setup {
-    cmd = { "npx", "typescript-language-server", "--stdio" },
-    filetypes = {
-        "javascript",
-        "javascriptreact",
-        "javascript.jsx",
-        "typescript",
-        "typescriptreact",
-        "typescript.tsx",
-    },
+require("mason-lspconfig").setup_handlers({
+    function(server_name)
+        lspconfig[server_name].setup {}
+    end,
+    ["tsserver"] = function()
+        lspconfig.tsserver.setup {
+            cmd = { "npx", "typescript-language-server", "--stdio" },
+            filetypes = {
+                "javascript",
+                "javascriptreact",
+                "javascript.jsx",
+                "typescript",
+                "typescriptreact",
+                "typescript.tsx",
+            },
 
-    init_options = {
-        hostInfo = "neovim"
-    },
-    root_dir = lspconfig.util.root_pattern("package.json", "tsconfig.json", "jsconfig.json", ".git"),
-}
---}}}
-
--- lua{{{
-local runtime_path = vim.split(package.path, ';')
-table.insert(runtime_path, ".config/nvim/lua/?.lua")
-table.insert(runtime_path, ".config/nvim/lua/?/init.lua")
---}}}
-
--- clangd {{{
-require 'lspconfig'.clangd.setup {}
--- }}}
-
--- gopls {{{
-lspconfig.gopls.setup {
-    root_dir = lspconfig.util.root_pattern("go.mod", ".git", "main.go")
-}
--- }}}
-
---}}}
-
--- }}}
+            init_options = {
+                hostInfo = "neovim"
+            },
+            root_dir = lspconfig.util.root_pattern("package.json", "tsconfig.json", "jsconfig.json", ".git"),
+        }
+    end,
+    ["gopls"] = function()
+        lspconfig.gopls.setup {
+            root_dir = lspconfig.util.root_pattern("go.mod", ".git", "main.go")
+        }
+    end,
+})

--- a/lua/plugins.lua
+++ b/lua/plugins.lua
@@ -331,22 +331,6 @@ require('packer').startup({ function()
     -- Languages/Filetypes {{{
     use "nathom/filetype.nvim"
 
-    -- Neovim lua writing
-    use {
-        "folke/lua-dev.nvim",
-        config = function() --{{{
-            local luadev = require("lua-dev").setup({
-                lspconfig = {
-                    cmd = { vim.fn.stdpath('data') ..
-                        "/lsp_servers/sumneko_lua/extension/server/bin/lua-language-server" }
-                },
-            })
-
-            local lspconfig = require('lspconfig')
-            lspconfig.sumneko_lua.setup(luadev)
-        end --}}}
-    }
-
     -- Ansible
     use {
         'pearofducks/ansible-vim',
@@ -648,10 +632,15 @@ require('packer').startup({ function()
     }
 
     use {
-        'neovim/nvim-lspconfig'
+        "williamboman/mason.nvim",
     }
+
     use {
-        'williamboman/nvim-lsp-installer'
+        "williamboman/mason-lspconfig.nvim",
+    }
+
+    use {
+        "neovim/nvim-lspconfig"
     }
 
     use {


### PR DESCRIPTION
Migrate to mason as nvim-lsp-installer is now deprecated.

Create handler functions for newly installed language servers.

Remove luadev as it doesn't appear critical.